### PR TITLE
Fix scoring of set matching

### DIFF
--- a/src/metametric/core/matching.py
+++ b/src/metametric/core/matching.py
@@ -24,6 +24,10 @@ class SetMatchingMetric(Metric[Collection[T]]):
         """Score two sets of objects."""
         if isinstance(self.inner, DiscreteMetric) and self.constraint == MatchingConstraint.ONE_TO_ONE:
             return len(set(x) & set(y))
+        elif not x and not y:
+           return 1.0
+        elif not x or not y:
+           return 0.0
         else:
             m = self.inner.gram_matrix(x, y)
             if self.constraint == MatchingConstraint.ONE_TO_ONE:
@@ -42,7 +46,9 @@ class SetMatchingMetric(Metric[Collection[T]]):
 
     def score_self(self, x: Collection[T]) -> float:
         """Score a set of objects with itself."""
-        if self.constraint == MatchingConstraint.MANY_TO_MANY:
+        if not x:
+            return 1.0
+        elif self.constraint == MatchingConstraint.MANY_TO_MANY:
             return self.inner.gram_matrix(x, x).sum()
         elif self.constraint == MatchingConstraint.ONE_TO_ONE:
             return sum(self.inner.score_self(u) for u in x)

--- a/src/metametric/core/matching.py
+++ b/src/metametric/core/matching.py
@@ -22,12 +22,12 @@ class SetMatchingMetric(Metric[Collection[T]]):
 
     def score(self, x: Collection[T], y: Collection[T]) -> float:
         """Score two sets of objects."""
-        if isinstance(self.inner, DiscreteMetric) and self.constraint == MatchingConstraint.ONE_TO_ONE:
-            return len(set(x) & set(y))
-        elif not x and not y:
+        if not x and not y:
            return 1.0
         elif not x or not y:
            return 0.0
+        elif isinstance(self.inner, DiscreteMetric) and self.constraint == MatchingConstraint.ONE_TO_ONE:
+            return len(set(x) & set(y))
         else:
             m = self.inner.gram_matrix(x, y)
             if self.constraint == MatchingConstraint.ONE_TO_ONE:

--- a/tests/metametric/core/test_alignment.py
+++ b/tests/metametric/core/test_alignment.py
@@ -1,13 +1,43 @@
 """Tests for metrics derived with alignments."""
-import metametric.dsl as mm
+import src.metametric.dsl as mm
 
 
 def test_solve_alignment():
     """Test the alignment solver."""
     a = [1, 2, 2]
     b = [1, 1, 1, 2]
+    c = []
 
+    # non-empty prediction and non-empty reference
     assert mm.set_matching[int, '<->', 'none'](...).score(a, b) == 2
     assert mm.set_matching[int, '->', 'none'](...).score(a, b) == 3
     assert mm.set_matching[int, '<-', 'none'](...).score(a, b) == 4
     assert mm.set_matching[int, '~', 'none'](...).score(a, b) == 5
+
+    # empty reference
+    assert mm.set_matching[int, '<->', 'none'](...).score(a,c) == 0
+    assert mm.set_matching[int, '->', 'none'](...).score(a,c) == 0
+    assert mm.set_matching[int, '<-', 'none'](...).score(a,c) == 0
+    assert mm.set_matching[int, '~', 'none'](...).score(a,c) == 0
+
+    # empty prediction
+    assert mm.set_matching[int, '<->', 'none'](...).score(c,a) == 0
+    assert mm.set_matching[int, '->', 'none'](...).score(c,a) == 0
+    assert mm.set_matching[int, '<-', 'none'](...).score(c,a) == 0
+    assert mm.set_matching[int, '~', 'none'](...).score(c,a) == 0
+
+    # self-scoring
+    assert mm.set_matching[int, '<->', 'none'](...).score(a,a) == 2
+    assert mm.set_matching[int, '->', 'none'](...).score(a,a) == 3
+    assert mm.set_matching[int, '<-', 'none'](...).score(a,a) == 3
+    assert mm.set_matching[int, '~', 'none'](...).score(a,a) == 5
+
+    assert mm.set_matching[int, '<->', 'none'](...).score(b,b) == 2
+    assert mm.set_matching[int, '->', 'none'](...).score(b,b) == 4
+    assert mm.set_matching[int, '<-', 'none'](...).score(b,b) == 4
+    assert mm.set_matching[int, '~', 'none'](...).score(b,b) == 10
+
+    assert mm.set_matching[int, '<->', 'none'](...).score(c,c) == 1
+    assert mm.set_matching[int, '->', 'none'](...).score(c,c) == 1
+    assert mm.set_matching[int, '<-', 'none'](...).score(c,c) == 1
+    assert mm.set_matching[int, '~', 'none'](...).score(c,c) == 1

--- a/tests/metametric/core/test_alignment.py
+++ b/tests/metametric/core/test_alignment.py
@@ -1,5 +1,5 @@
 """Tests for metrics derived with alignments."""
-import src.metametric.dsl as mm
+import metametric.dsl as mm
 
 
 def test_solve_alignment():


### PR DESCRIPTION
This PR addresses issue #23 (finally getting around to this). However, it additionally modifies how set scoring works in cases where **both** the prediction and reference are empty sets.

Previously, this scenario would yield a score of 0, which seemed wrong to me, as it doesn’t distinguish between the case  where the predictions are (correctly) empty and the case where predictions are (incorrectly) non-empty. Now, this scenario returns a score of 1.0, but let me know if you think this is weird or undesirable too.